### PR TITLE
Allow for variable offset

### DIFF
--- a/lib/text_scroll.dart
+++ b/lib/text_scroll.dart
@@ -220,6 +220,9 @@ class _TextScrollState extends State<TextScroll> {
   void didUpdateWidget(covariant TextScroll oldWidget) {
     _onUpdate(oldWidget);
 
+    ///Update timer to adapt to changes in [widget.velocity]
+    _setTimer();
+
     super.didUpdateWidget(oldWidget);
   }
 
@@ -261,6 +264,15 @@ class _TextScrollState extends State<TextScroll> {
 
   Future<void> _initScroller(_) async {
     await _delayBefore();
+    _setTimer();
+  }
+
+  /// Sets [_timer] for animation
+  void _setTimer() {
+    ///Cancel previous timer if it exists
+    _timer?.cancel();
+    ///Reset [_running] to allow for updates on changed velocity
+    _running = false;
 
     _timer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
       if (!_available) {
@@ -296,7 +308,6 @@ class _TextScrollState extends State<TextScroll> {
           }
       }
     }
-
     _running = false;
   }
 
@@ -335,7 +346,6 @@ class _TextScrollState extends State<TextScroll> {
     );
     if (!_available) return;
     _scrollController.jumpTo(position.minScrollExtent);
-
     ///Pause between animation rounds
     if (widget.pauseBetween != null) {
       await Future.delayed(widget.pauseBetween!);
@@ -375,6 +385,9 @@ class _TextScrollState extends State<TextScroll> {
   }
 
   Duration _getDuration(double extent) {
+    ///No movement when velocity offset dx equals 0
+    if (widget.velocity.pixelsPerSecond.dx == 0) return Duration.zero;
+
     final int milliseconds =
         (extent * 1000 / widget.velocity.pixelsPerSecond.dx).round();
 


### PR DESCRIPTION
This refreshes the timer when a parent widget updates to allow changes in Velocity.

It enables this example:
```dart
GestureDetector(
    onTap: () {
         setState(() {
             _offset = Offset(_offset.dx + 100, 0);
        });
    },
    child: TextScroll(
        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ",
        velocity: Velocity(pixelsPerSecond: _offset),
    ),
),
```

And would fix #20 if using Offset.zero and changing it after a tap.