### PR TITLE
Border fade effect

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,6 +94,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 intervalSpaces: 10,
                 velocity: Velocity(pixelsPerSecond: Offset(50, 0)),
                 fadedBorder: true,
+                fadeBorderVisibility: FadeBorderVisibility.auto,
+                fadeBorderSide: FadeBorderSide.both,
               ),
             ],
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,7 +87,14 @@ class _MyHomePageState extends State<MyHomePage> {
               const TextScroll(
                 'Hey! I\'m a RTL text, check me out. Hey! I\'m a RTL text, check me out. Hey! I\'m a RTL text, check me out. ',
                 textDirection: TextDirection.rtl,
-              )
+              ),
+              const SizedBox(height: 20),
+              const TextScroll(
+                'This is the sample text for Flutter TextScroll widget with faded border.',
+                intervalSpaces: 10,
+                velocity: Velocity(pixelsPerSecond: Offset(50, 0)),
+                fadedBorder: true,
+              ),
             ],
           ),
         ),

--- a/lib/text_scroll.dart
+++ b/lib/text_scroll.dart
@@ -38,6 +38,7 @@ class TextScroll extends StatefulWidget {
     this.intervalSpaces,
     this.fadedBorder = false,
     this.fadedBorderWidth = 0.2,
+    this.fadeBorderSide = FadeBorderSide.both,
   }) : super(key: key);
 
   /// The text string, that would be scrolled.
@@ -223,6 +224,20 @@ class TextScroll extends StatefulWidget {
   /// ```
   final double? fadedBorderWidth;
 
+  /// Sets which side of the widget should be faded.
+  /// Default is [FadeBorderSide.both].
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// TextScroll(
+  ///  'This is the sample text for Flutter TextScroll widget. ',
+  ///  fadedBorder: true,
+  ///  fadeBorderSide: FadeBorderSide.left,
+  ///  )
+  ///  ```
+  final FadeBorderSide fadeBorderSide;
+
   @override
   State<TextScroll> createState() => _TextScrollState();
 }
@@ -299,8 +314,18 @@ class _TextScrollState extends State<TextScroll> {
       }, growable: true);
 
       ///Add black color to add gradient fade out
-      colors.insert(0, Colors.black);
-      colors.add(Colors.black);
+      if (widget.fadeBorderSide == FadeBorderSide.both ||
+          widget.fadeBorderSide == FadeBorderSide.left) {
+        colors.insert(0, Colors.black);
+      } else {
+        colors.add(Colors.transparent);
+      }
+      if (widget.fadeBorderSide == FadeBorderSide.both ||
+          widget.fadeBorderSide == FadeBorderSide.right) {
+        colors.add(Colors.black);
+      } else {
+        colors.add(Colors.transparent);
+      }
 
       ///Calculate the stops for the gradient
       final List<double> stops =
@@ -483,3 +508,10 @@ enum TextScrollMode {
   bouncing,
   endless,
 }
+
+/// Side of the text border to fade out.
+///
+/// [left] - fade out left side of the text.
+/// [right] - fade out right side of the text.
+/// [both] - fade out both sides of the text.
+enum FadeBorderSide { left, right, both }


### PR DESCRIPTION
This adds the possibility of making the text fade out on the left, right, or both sides.

It is by default disabled to prevent breaking changes.

Developers can define how much should be faded out by using "fadedBorderWidth" and which side should the fade effect be applied to (via "fadeBorderSide").

Added a new example for this:

Screenshot:
![image](https://user-images.githubusercontent.com/46051388/210437889-13402b5a-4e9b-4478-b4f1-c903525d826d.png)
