### PR TITLE
Add ConstrainedBox above Text

### DIFF
--- a/lib/text_scroll.dart
+++ b/lib/text_scroll.dart
@@ -238,21 +238,25 @@ class _TextScrollState extends State<TextScroll> {
     return Directionality(
       textDirection: widget.textDirection,
       child: SingleChildScrollView(
-        controller: _scrollController,
-        physics: NeverScrollableScrollPhysics(),
-        scrollDirection: Axis.horizontal,
-        child: widget.selectable
-            ? SelectableText(
-                _endlessText ?? widget.text,
-                style: widget.style,
-                textAlign: widget.textAlign,
-              )
-            : Text(
-                _endlessText ?? widget.text,
-                style: widget.style,
-                textAlign: widget.textAlign,
-              ),
-      ),
+          controller: _scrollController,
+          physics: NeverScrollableScrollPhysics(),
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minWidth: _scrollController.position.viewportDimension,
+            ),
+            child: widget.selectable
+                ? SelectableText(
+                    _endlessText ?? widget.text,
+                    style: widget.style,
+                    textAlign: widget.textAlign,
+                  )
+                : Text(
+                    _endlessText ?? widget.text,
+                    style: widget.style,
+                    textAlign: widget.textAlign,
+                  ),
+          )),
     );
   }
 


### PR DESCRIPTION
Fix bug: when Expanded is parent of TextScroll, textAlign is useless